### PR TITLE
Fix filter_regex on Windows (regex compiled as path → broke dol.Jsons)

### DIFF
--- a/dol/tests/test_trans.py
+++ b/dol/tests/test_trans.py
@@ -1,6 +1,38 @@
 """Test trans.py functionality."""
 
-from dol.trans import filt_iter, redirect_getattr_to_getitem
+import dol.util
+from dol.trans import (
+    filt_iter,
+    filter_prefixes,
+    filter_regex,
+    filter_suffixes,
+    redirect_getattr_to_getitem,
+)
+
+
+def test_filter_regex_is_os_independent():
+    """Regex filters must compile as REGEXES, not as path templates.
+
+    Regression for a Windows-only bug: ``filter_regex`` used the path-oriented
+    ``safe_compile``, which ``re.escape``s its input on Windows. That turned a
+    pattern like ``(\\.json)$`` into a literal matcher, so ``filter_suffixes('.json')``
+    rejected every ``*.json`` key on Windows and ``dol.Jsons`` raised
+    ``KeyError: 'Key not in store: <key>.json'`` on write.
+    """
+    real_system = dol.util.platform.system
+    try:
+        # Simulate every platform, including Windows (the broken one).
+        for system in ("Linux", "Darwin", "Windows"):
+            dol.util.platform.system = lambda system=system: system
+            assert bool(filter_regex(r"(\.json)$")("doc-001.json")) is True
+            assert bool(filter_regex(r"(\.json)$")("doc-001.txt")) is False
+            assert bool(filter_suffixes(".json")("doc-001.json")) is True
+            assert bool(filter_suffixes([".txt", ".doc"])("report.doc")) is True
+            assert bool(filter_suffixes(".json")("doc-001.txt")) is False
+            assert bool(filter_prefixes("test")("test_image.jpg")) is True
+            assert bool(filter_prefixes("test")("report.doc")) is False
+    finally:
+        dol.util.platform.system = real_system
 
 
 def test_filt_iter():

--- a/dol/trans.py
+++ b/dol/trans.py
@@ -1481,9 +1481,21 @@ def filter_regex(regex, *, return_search_func=False):
     >>> is_txt("report.doc")
     False
 
+    The argument is a *regular expression*, so it is compiled with ``re.compile``
+    -- NOT ``safe_compile`` (which is for file-path templates and ``re.escape``s its
+    input on Windows). Using ``safe_compile`` here silently broke every regex filter
+    on Windows: e.g. ``filter_suffixes('.json')`` (used by ``Jsons``) had its
+    ``(\.json)$`` pattern escaped into a literal string matcher, so no ``*.json`` key
+    matched and the store raised ``KeyError: 'Key not in store: <key>.json'``.
+
+    >>> is_json = filter_regex(r"(\.json)$")  # works identically on every OS
+    >>> is_json("doc-001.json")
+    True
+    >>> is_json("doc-001.txt")
+    False
     """
     if isinstance(regex, str):
-        regex = safe_compile(regex)
+        regex = re.compile(regex)
     if return_search_func:
         return regex.search
     else:


### PR DESCRIPTION
## The bug
`filter_regex` compiled its pattern with `safe_compile`, which is intended for
**file-path templates** and `re.escape`s its input on Windows. That turned a real
regex like `(\.json)$` into a **literal-string matcher** on Windows, so every
regex key-filter silently broke there.

Most visibly, `filter_suffixes('.json')` backs **`dol.Jsons`** (via
`@filt_iter.suffixes('.json')`): with the pattern escaped, no `*.json` key matched
the filter, so any write/read raised:

```
KeyError: 'Key not in store: <key>.json'
```

This breaks every `dol.Jsons`-backed store on Windows (surfaced by a downstream
package's Windows CI).

## The fix
`filter_regex`'s argument is a **regex** by contract, so compile it with
`re.compile`. `safe_compile` is left untouched and still used for actual path
templates (`mk_pattern_from_template_and_format_dict`), where its Windows escaping
is correct.

macOS/Linux behavior is unchanged: there `safe_compile` only ran `os.path.normpath`
(a no-op for these patterns) before `re.compile`.

## Verification
- New OS-independent regression test simulating Linux/Darwin/**Windows**.
- Full `dol/tests` suite green (106 passed, 2 skipped); the 2 pre-existing
  doctest failures (`double_up_as_factory`, `invertible_maps`) are unrelated and
  also fail on `master`.
- End-to-end: a `dol.Jsons` write+read+list works under a forced
  `platform.system()=="Windows"` with this fix (fails without it).

https://claude.ai/code/session_019bFtivmtdcXDoCQt3B9gGp