### PR TITLE
Add combinatorial regression tests for mk_dirs_if_missing (closes #14)

### DIFF
--- a/dol/tests/test_mk_dirs_if_missing.py
+++ b/dol/tests/test_mk_dirs_if_missing.py
@@ -1,0 +1,77 @@
+"""Combinatorial regression tests for ``mk_dirs_if_missing`` (Issue #14).
+
+Issue #14 reported two fragilities, both of which are resolved on current dol; these
+tests lock the behavior in (the issue explicitly asked for "more combinatorial wrapper
+testing"):
+
+1. **Read ops on a fresh store whose root dir does not exist yet** return empty /
+   ``KeyError`` instead of raising a filesystem error (``list`` -> ``[]``, ``len`` -> 0,
+   ``in`` -> ``False``, ``__getitem__`` -> ``KeyError``).
+2. **``mk_dirs_if_missing`` composes with ``wrap_kvs`` in BOTH orders** (the
+   ``mk_dirs_if_missing(wrap_kvs(G))`` ordering previously raised ``FileNotFoundError: ''``).
+"""
+
+import os
+
+import pytest
+
+from dol import Files, JsonFiles, mk_dirs_if_missing, wrap_kvs
+
+
+def _nonexistent_rootdir(tmp_path):
+    """A rootdir two levels below tmp_path that does NOT exist yet."""
+    return os.path.join(str(tmp_path), "A", "B")
+
+
+def test_read_ops_on_fresh_missing_dir(tmp_path):
+    rootdir = _nonexistent_rootdir(tmp_path)
+    assert not os.path.exists(rootdir)
+    s = mk_dirs_if_missing(Files)(rootdir)
+    assert list(s) == []
+    assert len(s) == 0
+    assert "x" not in s
+    with pytest.raises(KeyError):
+        s["missing"]
+
+
+class _G(Files):
+    """A trivial Files subclass, to exercise wrapping a user-defined store class."""
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: mk_dirs_if_missing(Files),
+        lambda: mk_dirs_if_missing(_G),
+        lambda: wrap_kvs(mk_dirs_if_missing(_G)),
+        lambda: mk_dirs_if_missing(wrap_kvs(_G)),  # used to raise FileNotFoundError: ''
+        lambda: mk_dirs_if_missing(mk_dirs_if_missing(Files)),
+    ],
+    ids=[
+        "mk_dirs(Files)",
+        "mk_dirs(G)",
+        "wrap_kvs(mk_dirs(G))",
+        "mk_dirs(wrap_kvs(G))",
+        "mk_dirs(mk_dirs(Files))",
+    ],
+)
+def test_wrap_ordering_writes_and_makes_dirs(tmp_path, factory):
+    s = factory()(_nonexistent_rootdir(tmp_path))
+    # write to a key at the (missing) root: the root dirs are created on write
+    s["foo"] = b"bar"
+    assert s["foo"] == b"bar"
+    # write to a key whose intermediate subdirs also don't exist yet
+    deep = os.path.join("sub", "deep", "foo")
+    s[deep] = b"baz"
+    assert s[deep] == b"baz"
+    assert set(s) >= {"foo", deep}
+
+
+def test_mk_dirs_with_value_transform(tmp_path):
+    """mk_dirs_if_missing composes with a value codec (JsonFiles) + deep keys."""
+    s = mk_dirs_if_missing(JsonFiles)(_nonexistent_rootdir(tmp_path))
+    s["a.json"] = {"x": 1}
+    assert s["a.json"] == {"x": 1}
+    deep = os.path.join("sub", "deep", "b.json")
+    s[deep] = {"y": 2}
+    assert s[deep] == {"y": 2}


### PR DESCRIPTION
## What

[#14](https://github.com/i2mint/dol/issues/14) reported two `mk_dirs_if_missing` fragilities. **Both are resolved on current dol** — verified by running the issue's exact repros — so this PR adds the *combinatorial wrapper testing* the issue explicitly asked for, to lock the behavior in.

## Verified resolved

**1. Read ops on a fresh store whose root dir doesn't exist yet** (the issue's `list(s)` → `FileNotFoundError` repro):
```python
s = mk_dirs_if_missing(Files)(nonexistent_dir)
list(s)      # []          (was: FileNotFoundError)
len(s)       # 0
'x' in s     # False
s['missing'] # KeyError     (was: a "directory doesn't exist" error)
```

**2. Wrap-ordering** — `mk_dirs_if_missing(wrap_kvs(G))` (which raised `FileNotFoundError: ''`) now works, as does every other ordering. The triage predicted this ("the ordering fragility may partly dissolve once the wrapping convention is settled") — it did, once the Wave-1 `wrap_kvs` work landed.

## Tests (7, cross-platform)

Read-ops-on-missing-dir; the 5 wrap orderings (`mk_dirs(Files)`, `mk_dirs(G)`, `wrap_kvs(mk_dirs(G))`, `mk_dirs(wrap_kvs(G))`, `mk_dirs(mk_dirs(Files))`) each writing a root key **and** a deep new-key path (subdir creation); and `mk_dirs(JsonFiles)` value-transform composition.

**Minor known residual (not blocking):** the `KeyError` on a missing key carries the raw FS message (`[Errno 2] No such file...`) rather than naming the key — the exception *type* is correct (the issue's ask), only the message is cosmetic. Cleaning it touches a 24-dependent core `Files` decorator, so it's left for a separate change.

Closes #14

https://claude.ai/code/session_01H8PmV6xmMhzV64zi1Twraw