### PR TITLE
Skip unreadable dirs in recursive file walk (closes #3)

### DIFF
--- a/dol/filesys.py
+++ b/dol/filesys.py
@@ -41,7 +41,11 @@ def paths_in_dir(rootdir, include_hidden=False):
                     yield ensure_slash_suffix(filepath)
                 else:
                     yield filepath
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        # Skip directories that vanished, aren't directories, or aren't readable rather
+        # than crashing the (recursive) walk. Notably, OS-protected directories such as
+        # macOS's ``.../com.apple.*/TemporaryItems/`` under the temp dir raise
+        # PermissionError from ``os.listdir`` (Issue #3).
         pass
 
 

--- a/dol/tests/test_walk_permissions.py
+++ b/dol/tests/test_walk_permissions.py
@@ -1,0 +1,47 @@
+"""Regression test for Issue #3: the recursive file walk must skip unreadable dirs.
+
+``FileBytesReader(gettempdir())`` used to raise ``PermissionError`` because ``os.listdir``
+hits OS-protected subdirectories (e.g. macOS's ``.../com.apple.*/TemporaryItems/``). The
+walk now skips directories it cannot read instead of crashing.
+"""
+
+import os
+import sys
+
+import pytest
+
+from dol.filesys import FileBytesReader, paths_in_dir
+
+
+def test_recursive_walk_skips_unreadable_dirs(tmp_path):
+    # a readable file at the root
+    (tmp_path / "readable.txt").write_bytes(b"hi")
+    # a subdirectory we will make unreadable
+    protected = tmp_path / "protected"
+    protected.mkdir()
+    (protected / "secret.txt").write_bytes(b"nope")
+
+    if sys.platform.startswith("win"):
+        pytest.skip("POSIX directory permissions don't apply on Windows")
+
+    os.chmod(protected, 0o000)
+    try:
+        # If we can still list it (e.g. running as root), the scenario is unreachable.
+        try:
+            os.listdir(protected)
+            pytest.skip("cannot make a directory unreadable in this environment")
+        except PermissionError:
+            pass
+
+        # The walk must not raise, and must skip the unreadable subdir's contents.
+        s = FileBytesReader(str(tmp_path))
+        keys = list(s)  # was: PermissionError
+        assert any(k.endswith("readable.txt") for k in keys)
+        assert not any(k.endswith("secret.txt") for k in keys)
+    finally:
+        os.chmod(protected, 0o755)  # restore so tmp cleanup can remove it
+
+
+def test_paths_in_dir_on_missing_dir_is_empty(tmp_path):
+    missing = str(tmp_path / "does_not_exist")
+    assert list(paths_in_dir(missing)) == []


### PR DESCRIPTION
## What

`FileBytesReader(gettempdir())` (Issue #3) raised `PermissionError [Errno 1] Operation not permitted` because the recursive walk's `paths_in_dir` caught only `FileNotFoundError`, so `os.listdir` on an OS-protected subdir (macOS's `.../com.apple.*/TemporaryItems/`) crashed the whole walk.

## Fix

Extend the caught set to `(FileNotFoundError, NotADirectoryError, PermissionError)` — skip directories that vanished, aren't directories, or aren't readable, instead of crashing.

```python
s = FileBytesReader(gettempdir())
list(s)   # 3970 keys  (was: PermissionError)
```

## Tests + safety

- Deterministic regression test: a `chmod 000` subdir is skipped while readable siblings are still returned (POSIX-only; skipped on Windows / when running as root).
- **Dependents test-gate (all 56 with tests): 39 pass, 0 PASS→FAIL** — the 17 non-passing fail identically at baseline (pre-existing env issues). The change is robustness-only (it only alters behavior where `os.listdir` previously *crashed*).

Closes #3

https://claude.ai/code/session_01H8PmV6xmMhzV64zi1Twraw